### PR TITLE
cqsub to qsub for Cobalt provider

### DIFF
--- a/cogkit/modules/provider-localscheduler/src/org/globus/cog/abstraction/impl/scheduler/cobalt/CobaltExecutor.java
+++ b/cogkit/modules/provider-localscheduler/src/org/globus/cog/abstraction/impl/scheduler/cobalt/CobaltExecutor.java
@@ -1,3 +1,22 @@
+/*
+* Swift Parallel Scripting Language (http://swift-lang.org)
+* Code from Java CoG Kit Project (see notice below) with modifications.
+*
+* Copyright 2005-2014 University of Chicago
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 //----------------------------------------------------------------------
 //This code is developed as part of the Java CoG Kit project
 //The terms of the license can be found at http://www.cogkit.org/license

--- a/cogkit/modules/provider-localscheduler/src/org/globus/cog/abstraction/impl/scheduler/cobalt/CobaltJob.java
+++ b/cogkit/modules/provider-localscheduler/src/org/globus/cog/abstraction/impl/scheduler/cobalt/CobaltJob.java
@@ -1,3 +1,23 @@
+/*
+* Swift Parallel Scripting Language (http://swift-lang.org)
+* Code from Java CoG Kit Project (see notice below) with modifications.
+*
+* Copyright 2005-2014 University of Chicago
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
 //----------------------------------------------------------------------
 //This code is developed as part of the Java CoG Kit project
 //The terms of the license can be found at http://www.cogkit.org/license

--- a/cogkit/modules/provider-localscheduler/src/org/globus/cog/abstraction/impl/scheduler/cobalt/Properties.java
+++ b/cogkit/modules/provider-localscheduler/src/org/globus/cog/abstraction/impl/scheduler/cobalt/Properties.java
@@ -1,3 +1,23 @@
+/*
+* Swift Parallel Scripting Language (http://swift-lang.org)
+* Code from Java CoG Kit Project (see notice below) with modifications.
+*
+* Copyright 2005-2014 University of Chicago
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
 //----------------------------------------------------------------------
 //This code is developed as part of the Java CoG Kit project
 //The terms of the license can be found at http://www.cogkit.org/license

--- a/cogkit/modules/provider-localscheduler/src/org/globus/cog/abstraction/impl/scheduler/cobalt/QueuePoller.java
+++ b/cogkit/modules/provider-localscheduler/src/org/globus/cog/abstraction/impl/scheduler/cobalt/QueuePoller.java
@@ -1,3 +1,23 @@
+/*
+* Swift Parallel Scripting Language (http://swift-lang.org)
+* Code from Java CoG Kit Project (see notice below) with modifications.
+*
+* Copyright 2005-2014 University of Chicago
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
 //----------------------------------------------------------------------
 //This code is developed as part of the Java CoG Kit project
 //The terms of the license can be found at http://www.cogkit.org/license


### PR DESCRIPTION
Note that in the first commit, I mistakenly removed the boilerplate copyright blurb which is back in the second commit. In short nothing to worry about the large red and green patches of text.
